### PR TITLE
propagate use_bias flag to KerasMatrixFactorizer

### DIFF
--- a/fancyimpute/matrix_factorization.py
+++ b/fancyimpute/matrix_factorization.py
@@ -91,7 +91,8 @@ class MatrixFactorization(Solver):
             rank=self.rank,
             input_dim_i=n_samples,
             input_dim_j=n_features,
-            embeddings_regularizer=regularizers.l2(self.l2_penalty)
+            embeddings_regularizer=regularizers.l2(self.l2_penalty),
+            use_bias=self.use_bias
         )(main_input)
         model = Model(inputs=main_input, outputs=embed)
         optimizer = import_from(


### PR DESCRIPTION
I'm guessing the intent is to pass the flag to KerasMatrixFactorizer, since nothing is currently being done with it.