### PR TITLE
Update travis to stop checking on python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
     - CUDA_VISIBLE_DEVICES=""
 matrix:
   include:
-    - python: 2.7
     - python: 3.6
 before_install:
   # Commands below copied from: http://conda.pydata.org/docs/travis.html


### PR DESCRIPTION
The newest sklearn with `IterativeImputer` doesn't support 2.7 so neither should we!

